### PR TITLE
プロンプトにホスト名を省略せず表示するように変更した。

### DIFF
--- a/.git-prompt
+++ b/.git-prompt
@@ -13,7 +13,7 @@ function promps {
         xterm*) TITLEBAR='\[\e]0;\W\007\]';;
         *)      TITLEBAR="";;
     esac
-    local BASE="\u@\h"
+    local BASE="\u@$(hostname)"
     PS1="${TITLEBAR}${GREEN}${BASE}${WHITE}:${BLUE}\W${GREEN}\$(parse_git_branch)${BLUE}\$${WHITE} "
 }
 promps


### PR DESCRIPTION
省略したホスト名だと情報が足りないことがあるため、冗長だがすべて表示するように変更した。